### PR TITLE
[#14] Set default themes for UAS install profile

### DIFF
--- a/docroot/profiles/unallocated/unallocated.install
+++ b/docroot/profiles/unallocated/unallocated.install
@@ -3,7 +3,7 @@
 /**
  * Implements hook_install().
  */
-function whistlepunk_install() {
+function unallocated_install() {
   include_once DRUPAL_ROOT . '/profiles/standard/standard.install';
   standard_install();
   
@@ -11,10 +11,29 @@ function whistlepunk_install() {
   variable_set('jquery_update_jquery_version', '1.7');
   variable_set('jquery_update_jquery_cdn', 'google');
   
-  // Set the default theme.
   $theme = 'uas';
-  theme_enable(array($theme));
+  $admin_theme = 'seven';
+
+  // Set the default theme.
+  db_update('system')
+    ->fields(array('status' => 1))
+    ->condition('type', 'theme')
+    ->condition('name', $theme)
+    ->execute();
   variable_set('theme_default', $theme);
+
+  // Enable the admin theme.
+  db_update('system')
+    ->fields(array('status' => 1))
+    ->condition('type', 'theme')
+    ->condition('name', $admin_theme)
+    ->execute();
+  variable_set('admin_theme', $admin_theme);
+  variable_set('node_admin_theme', '1');
+
+  // Disable the default Bartik theme
+  theme_disable(array('bartik'));
+
 
   menu_rebuild();
 }


### PR DESCRIPTION
-Set 'seven' as default admin theme
-Set 'uas' as default theme
-Removed 'bartik' from enabled themes'
